### PR TITLE
add vgg model net param to keep the same with resnet training script for fp16

### DIFF
--- a/benchmark/collective/resnet/models/vgg.py
+++ b/benchmark/collective/resnet/models/vgg.py
@@ -39,7 +39,7 @@ class VGGNet():
         self.params = train_parameters
         self.layers = layers
 
-    def net(self, input, class_dim=1000):
+    def net(self, input, args, class_dim=1000):
         layers = self.layers
         vgg_spec = {
             11: ([1, 1, 2, 2, 2]),


### PR DESCRIPTION
fix bug of updating common-use  function in resnet and vgg model.
