### PR TITLE
add recompute to resnet benchmark

### DIFF
--- a/benchmark/collective/resnet/models/resnet.py
+++ b/benchmark/collective/resnet/models/resnet.py
@@ -41,6 +41,7 @@ class ResNet():
     def __init__(self, layers=50):
         self.params = train_parameters
         self.layers = layers
+        self.checkpoints = []
 
     def net(self, input, args, class_dim=1000):
         layers = self.layers
@@ -60,6 +61,7 @@ class ResNet():
 
         conv = self.conv_bn_layer(
             input=input, num_filters=64, filter_size=7, stride=2, act='relu',name="conv1", data_format=args.data_format)
+        self.checkpoints.append(conv)
         conv = fluid.layers.pool2d(
             input=conv,
             pool_size=3,
@@ -67,6 +69,7 @@ class ResNet():
             pool_padding=1,
             pool_type='max',
             data_format=args.data_format)
+        self.checkpoints.append(conv)
         if layers >= 50:
             for block in range(len(depth)):
                 for i in range(depth[block]):
@@ -81,9 +84,12 @@ class ResNet():
                         input=conv,
                         num_filters=num_filters[block],
                         stride=2 if i == 0 and block != 0 else 1, name=conv_name, data_format=args.data_format)
+                    self.checkpoints.append(conv)
 
             pool = fluid.layers.pool2d(
                 input=conv, pool_size=7, pool_type='avg', global_pooling=True, data_format=args.data_format)
+
+            self.checkpoints.append(pool)
             if args.data_format == "NCHW":
                 stdv = 1.0 / math.sqrt(pool.shape[1] * 1.0)
             else:
@@ -92,6 +98,7 @@ class ResNet():
                                   size=class_dim,
                                   param_attr=fluid.param_attr.ParamAttr(
                                       initializer=fluid.initializer.Uniform(-stdv, stdv)))
+            self.checkpoints.append(out)
         else:
             for block in range(len(depth)):
                 for i in range(depth[block]):

--- a/benchmark/collective/resnet/scripts/train_gpu.sh
+++ b/benchmark/collective/resnet/scripts/train_gpu.sh
@@ -87,4 +87,5 @@ python -m paddle.distributed.launch ${distributed_args}  --log_dir log \
        --fetch_steps=10 \
        --do_test=True \
        --profile=False \
-       --rampup_begin_step=${DGC_RAMPUP_BEGIN_STEP}
+       --rampup_begin_step=${DGC_RAMPUP_BEGIN_STEP} \
+       --use_recompute=False

--- a/benchmark/collective/resnet/scripts/train_gpu_recompute.sh
+++ b/benchmark/collective/resnet/scripts/train_gpu_recompute.sh
@@ -1,0 +1,91 @@
+#!/bin/bash
+export FLAGS_sync_nccl_allreduce=1
+export FLAGS_cudnn_exhaustive_search=1
+export FLAGS_conv_workspace_size_limit=0 #MB
+export FLAGS_cudnn_batchnorm_spatial_persistent=1
+
+export GLOG_v=1
+export GLOG_logtostderr=1
+export FLAGS_eager_delete_tensor_gb=0
+export NCCL_DEBUG=INFO
+# Unset proxy
+unset https_proxy http_proxy
+
+set -xe
+
+MODEL=ResNet50 #VGG16
+MODEL_SAVE_PATH="output/"
+
+# training params
+NUM_EPOCHS=90
+BATCH_SIZE=760
+LR=0.1
+LR_STRATEGY=piecewise_decay
+
+# data params
+DATA_PATH="./ImageNet"
+TOTAL_IMAGES=1281167
+CLASS_DIM=1000
+IMAGE_SHAPE=3,224,224
+DATA_FORMAT="NHWC"
+
+#gpu params
+FUSE=True
+NCCL_COMM_NUM=1
+NUM_THREADS=2
+USE_HIERARCHICAL_ALLREDUCE=False
+NUM_CARDS=8
+FP16=False #whether to use float16
+use_dali=False
+if [[ ${use_dali} == "True" ]]; then
+    export FLAGS_fraction_of_gpu_memory_to_use=0.8
+fi
+
+# dgc params
+USE_DGC=False # whether to use dgc
+ALL_CARDS=8
+START_EPOCHS=4 # start dgc after 4 epochs
+# add 1 in let, let will not return 1 when set START_EPOCHS=0
+let '_tmp_ans=((TOTAL_IMAGES+BATCH_SIZE*ALL_CARDS-1)/(BATCH_SIZE*ALL_CARDS))*START_EPOCHS' 1
+DGC_RAMPUP_BEGIN_STEP=${_tmp_ans}
+
+if [[ ${FUSE} == "True" ]]; then
+    export FLAGS_fuse_parameter_memory_size=16 #MB
+    export FLAGS_fuse_parameter_groups_size=50
+fi
+distributed_args=""
+if [[ ${NUM_CARDS} == "1" ]]; then
+    distributed_args="--selected_gpus 0"
+fi
+
+set -x
+
+python -m paddle.distributed.launch ${distributed_args}  --log_dir log \
+       ./train_with_fleet.py \
+       --model=${MODEL} \
+       --batch_size=${BATCH_SIZE} \
+       --total_images=${TOTAL_IMAGES} \
+       --data_dir=${DATA_PATH} \
+       --class_dim=${CLASS_DIM} \
+       --image_shape=${IMAGE_SHAPE} \
+       --data_format=${DATA_FORMAT} \
+       --model_save_dir=${MODEL_SAVE_PATH} \
+       --with_mem_opt=False \
+       --lr_strategy=${LR_STRATEGY} \
+       --lr=${LR} \
+       --num_epochs=${NUM_EPOCHS} \
+       --l2_decay=1e-4 \
+       --scale_loss=128.0 \
+       --use_dynamic_loss_scaling=True \
+       --fuse=${FUSE} \
+       --num_threads=${NUM_THREADS} \
+       --nccl_comm_num=${NCCL_COMM_NUM} \
+       --use_hierarchical_allreduce=${USE_HIERARCHICAL_ALLREDUCE} \
+       --fp16=${FP16} \
+       --use_dali=${use_dali} \
+       --use_dgc=${USE_DGC} \
+       --fetch_steps=10 \
+       --do_test=True \
+       --profile=False \
+       --rampup_begin_step=${DGC_RAMPUP_BEGIN_STEP} \
+       --use_recompute=True

--- a/benchmark/collective/resnet/train_with_fleet.py
+++ b/benchmark/collective/resnet/train_with_fleet.py
@@ -96,6 +96,7 @@ add_arg('rampup_begin_step', int,   5008,           "The beginning step from whi
 add_arg('image_mean', nargs='+', type=float, default=[0.485, 0.456, 0.406], help="The mean of input image data")
 add_arg('image_std', nargs='+', type=float, default=[0.229, 0.224, 0.225], help="The std of input image data")
 add_arg('interpolation',    int,  None,                 "The interpolation mode")
+add_arg('use_recompute',           bool,  False,          "Whether use Recompute Optimizer or not")
 
 def get_momentum_optimizer(momentum_kwargs, use_dgc=False, dgc_kwargs={}):
     if not use_dgc:
@@ -308,6 +309,10 @@ def build_program(is_train, main_prog, startup_prog, args, dist_strategy=None):
                     optimizer = fluid.contrib.mixed_precision.decorate(optimizer,
                                                                        init_loss_scaling=args.scale_loss,
                                                                        use_dynamic_loss_scaling=args.use_dynamic_loss_scaling)
+                if args.use_recompute:
+                   dist_strategy.forward_recompute = True
+                   dist_strategy.enable_sequential_execution=True
+                   dist_strategy.recompute_checkpoints = model.checkpoints
                 dist_optimizer = fleet.distributed_optimizer(optimizer, strategy=dist_strategy)
                 _, param_grads = dist_optimizer.minimize(avg_cost)
 
@@ -598,8 +603,10 @@ def train(args):
                 result['0']['result_log'] = dict()
                 result['0']['result_log']['acc1'] = acc1_logs
                 result['0']['result_log']['acc5'] = acc5_logs
-                # median speed of all epochs
+                # maximum speed of all epochs
                 result['1'] = max(train_speed_list) * num_trainers
+                result['14'] = args.batch_size
+
                 print(str(result))
                 f.writelines(str(result))
 


### PR DESCRIPTION
Add a benchmark for RecomputeOptimizer as it is an important strategy in Fleet.
I have tested the code on PaddleCloud.

### Results:

#### with max batch size

||speed with max batch size|max batch size|
|:---:|:---:|:---:|
|1 card | 247.27 ins/s|380|
|1 card+recompute|189.78 ins/s|780|
|8 cards|1896.03 ins/s|370|
|8 cards+recompute|1450.60 ins/s|760|
|2 node 16 cards| 3632.93 ins/s|370|
|2 node 16 cards+recompute| 2825.46 ins/s|740|


#### with default batch size (256)

training speed:

||without recompute | with recompute|
|:---:|:---:|:---:|
|1 node 8 cards| 1910.83 /  ins/s|1472.35 / ins/s|
|2 node 16 cards| 3673.15 / ins/s| 2875.44 / ins/s|

experiment context:

```shell
FLAGS_conv_workspace_size_limit=0
fp16=False
```

training with recompute example on a machine with 8 V100 cards:

```shell
sh scripts/train_gpu_recompute.sh
```