### PR TITLE
Add Fleet cpu example & add lr scheduler for models

### DIFF
--- a/examples/bert_app.py
+++ b/examples/bert_app.py
@@ -33,14 +33,14 @@ import time
 configs = X.parse_train_configs()
 role = role_maker.PaddleCloudRoleMaker(is_collective=True)
 fleet.init(role)
-# load Bert_large / Bert_base model
-model = X.applications.Bert_large()
-#model = X.applications.Bert_base()
+# load BertLarge / BertBase model
+model = X.applications.BertLarge()
+#model = X.applications.BertBase()
 
 data_loader = model.load_digital_dataset_from_file(
     data_dir='./train_data', vocab_path='./vocab.txt')
 
-learning_rate = X.applications.linear_warmup_decay(configs.lr, 4000, 1000000)
+learning_rate = X.utils.linear_warmup_decay(configs.lr, 4000, 1000000)
 exec_strategy = fluid.ExecutionStrategy()
 exec_strategy.num_threads = 2
 exec_strategy.num_iteration_per_drop_scope = 1
@@ -53,6 +53,6 @@ optimizer = fleet.distributed_optimizer(optimizer, dist_strategy)
 optimizer.minimize(model.loss)
 
 place = fluid.CUDAPlace(int(os.environ.get('FLAGS_selected_gpus', 0)))
-trainer = X.Trainer(place)
+trainer = X.MultiGPUTrainer(place)
 
 trainer.fit(model, data_loader, 10)

--- a/examples/bert_app.py
+++ b/examples/bert_app.py
@@ -52,7 +52,6 @@ optimizer = fluid.optimizer.Adam(learning_rate=learning_rate)
 optimizer = fleet.distributed_optimizer(optimizer, dist_strategy)
 optimizer.minimize(model.loss)
 
-place = fluid.CUDAPlace(int(os.environ.get('FLAGS_selected_gpus', 0)))
-trainer = X.MultiGPUTrainer(place)
+trainer = X.MultiGPUTrainer()
 
 trainer.fit(model, data_loader, 10)

--- a/examples/bert_app.py
+++ b/examples/bert_app.py
@@ -34,8 +34,8 @@ configs = X.parse_train_configs()
 role = role_maker.PaddleCloudRoleMaker(is_collective=True)
 fleet.init(role)
 # load Bert_large / Bert_base model
-#model = X.applications.Bert_large()
-model = X.applications.Bert_base()
+model = X.applications.Bert_large()
+#model = X.applications.Bert_base()
 
 data_loader = model.load_digital_dataset_from_file(
     data_dir='./train_data', vocab_path='./vocab.txt')
@@ -47,7 +47,7 @@ exec_strategy.num_iteration_per_drop_scope = 1
 dist_strategy = fleet.DistributedStrategy()
 dist_strategy.exec_strategy = exec_strategy
 dist_strategy.nccl_comm_num = 3
-print(configs.lr)
+
 optimizer = fluid.optimizer.Adam(learning_rate=learning_rate)
 optimizer = fleet.distributed_optimizer(optimizer, dist_strategy)
 optimizer.minimize(model.loss)

--- a/examples/ctr_app.py
+++ b/examples/ctr_app.py
@@ -1,0 +1,61 @@
+# Copyright (c) 2020 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import os
+import numpy as np
+import fleetx as X
+import paddle
+import paddle.fluid as fluid
+import paddle.distributed.fleet as fleet
+from py_reader_generator import CriteoDataset
+import paddle.distributed.fleet.base.role_maker as role_maker
+import time
+
+configs = X.parse_train_configs()
+role = role_maker.PaddleCloudRoleMaker()
+fleet.init(role)
+model = X.applications.MultiSlotCTR()
+loader = model.load_multislot_from_file('./ctr_data/train_data')
+
+dist_strategy = fleet.DistributedStrategy()
+dist_strategy.mode = 'PS'
+dist_strategy.a_sync = False
+#dist_strategy.a_sync = True
+#dist_strategy.a_sync_configs = {"k_steps": 10000, "send_queue_size": 32}
+
+optimizer = fluid.optimizer.SGD(learning_rate=0.0001)
+
+optimizer = fleet.distributed_optimizer(optimizer, dist_strategy)
+optimizer.minimize(model.loss)
+
+if fleet.is_server():
+    fleet.init_server()
+    fleet.run_server()
+else:
+    fleet.init_worker()
+    exe = fluid.Executor(fluid.CPUPlace())
+    exe.run(fluid.default_startup_program())
+    epochs = 10
+    for epoch in range(epochs):
+        for i, data in enumerate(loader()):
+            print("hi")
+            print(data[0])
+            start_time = time.time()
+            cost_val = exe.run(fluid.default_main_program(),
+                               feed=data,
+                               fetch_list=[model.loss.name])
+            end_time = time.time()
+            print("epoch %d,step %d, use time=%d\n, loss=%f" % (
+                (epoch), i, end_time - start_time, cost_val[0]))
+    fleet.stop_worker()

--- a/examples/ctr_app.py
+++ b/examples/ctr_app.py
@@ -22,7 +22,7 @@ configs = X.parse_train_configs()
 role = role_maker.PaddleCloudRoleMaker()
 fleet.init(role)
 model = X.applications.MultiSlotCTR()
-loader = model.load_multislot_from_file('./ctr_data/train_data')
+loader = model.load_criteo_from_file('./ctr_data/train_data')
 
 dist_strategy = fleet.DistributedStrategy()
 dist_strategy.a_sync = True
@@ -37,6 +37,5 @@ if fleet.is_server():
     fleet.init_server()
     fleet.run_server()
 else:
-    fleet.init_worker()
-    trainer = X.Trainer(fluid.CPUPlace())
+    trainer = X.CPUTrainer(fluid.CPUPlace())
     trainer.fit(model, loader, epoch=10)

--- a/examples/ctr_app.py
+++ b/examples/ctr_app.py
@@ -37,5 +37,5 @@ if fleet.is_server():
     fleet.init_server()
     fleet.run_server()
 else:
-    trainer = X.CPUTrainer(fluid.CPUPlace())
+    trainer = X.CPUTrainer()
     trainer.fit(model, loader, epoch=10)

--- a/examples/ctr_app.py
+++ b/examples/ctr_app.py
@@ -13,13 +13,10 @@
 # limitations under the License.
 
 import os
-import numpy as np
 import fleetx as X
-import paddle
 import paddle.fluid as fluid
 import paddle.distributed.fleet as fleet
 import paddle.distributed.fleet.base.role_maker as role_maker
-import time
 
 configs = X.parse_train_configs()
 role = role_maker.PaddleCloudRoleMaker()

--- a/examples/resnet_app.py
+++ b/examples/resnet_app.py
@@ -60,5 +60,5 @@ optimizer = fleet.distributed_optimizer(optimizer, strategy=dist_strategy)
 optimizer.minimize(model.loss)
 
 place = fluid.CUDAPlace(int(os.environ.get('FLAGS_selected_gpus', 0)))
-trainer = X.Trainer(place)
+trainer = X.MultiGPUTrainer(place)
 trainer.fit(model, loader, epoch=10, use_dali=True)

--- a/examples/resnet_app.py
+++ b/examples/resnet_app.py
@@ -60,25 +60,5 @@ optimizer = fleet.distributed_optimizer(optimizer, strategy=dist_strategy)
 optimizer.minimize(model.loss)
 
 place = fluid.CUDAPlace(int(os.environ.get('FLAGS_selected_gpus', 0)))
-exe = fluid.Executor(place)
-exe.run(fluid.default_startup_program())
-
-for epoch_id in range(2):
-    total_time = 0
-    step = 0
-    for data in loader:
-        if step >= 100:
-            start_time = time.time()
-        cost_val = exe.run(fluid.default_main_program(),
-                           feed=data,
-                           fetch_list=[model.loss.name])
-        if step >= 100:
-            end_time = time.time()
-            total_time += (end_time - start_time)
-            print(
-                "worker_index: %d, step%d cost = %f, total time cost = %f, average speed = %f, speed = %f"
-                % (fleet.worker_index(), step, cost_val[0], total_time,
-                   (step - 99) / total_time, 1 / (end_time - start_time)))
-        step += 1
-    if model.use_dali:
-        loader.reset()
+trainer = X.Trainer(place)
+trainer.fit(model, loader, epoch=10, use_dali=True)

--- a/examples/resnet_app.py
+++ b/examples/resnet_app.py
@@ -59,6 +59,5 @@ optimizer = fluid.optimizer.Momentum(
 optimizer = fleet.distributed_optimizer(optimizer, strategy=dist_strategy)
 optimizer.minimize(model.loss)
 
-place = fluid.CUDAPlace(int(os.environ.get('FLAGS_selected_gpus', 0)))
-trainer = X.MultiGPUTrainer(place)
+trainer = X.MultiGPUTrainer()
 trainer.fit(model, loader, epoch=10, use_dali=True)

--- a/examples/transformer_app.py
+++ b/examples/transformer_app.py
@@ -49,5 +49,5 @@ optimizer = fleet.distributed_optimizer(optimizer)
 optimizer.minimize(model.loss)
 
 place = fluid.CUDAPlace(int(os.environ.get('FLAGS_selected_gpus', 0)))
-trainer = X.Trainer(place)
+trainer = X.MultiGPUTrainer(place)
 trainer.fit(model, data_loader, epoch=10)

--- a/examples/transformer_app.py
+++ b/examples/transformer_app.py
@@ -48,6 +48,5 @@ dist_strategy = fleet.DistributedStrategy()
 optimizer = fleet.distributed_optimizer(optimizer)
 optimizer.minimize(model.loss)
 
-place = fluid.CUDAPlace(int(os.environ.get('FLAGS_selected_gpus', 0)))
-trainer = X.MultiGPUTrainer(place)
+trainer = X.MultiGPUTrainer()
 trainer.fit(model, data_loader, epoch=10)

--- a/examples/vgg_app.py
+++ b/examples/vgg_app.py
@@ -58,25 +58,5 @@ optimizer = fleet.distributed_optimizer(optimizer, strategy=dist_strategy)
 optimizer.minimize(model.loss)
 
 place = fluid.CUDAPlace(int(os.environ.get('FLAGS_selected_gpus', 0)))
-exe = fluid.Executor(place)
-exe.run(fluid.default_startup_program())
-
-for epoch_id in range(2):
-    total_time = 0
-    step = 0
-    for data in loader:
-        if step >= 100:
-            start_time = time.time()
-        cost_val = exe.run(fluid.default_main_program(),
-                           feed=data,
-                           fetch_list=[model.loss.name])
-        if step >= 100:
-            end_time = time.time()
-            total_time += (end_time - start_time)
-            print(
-                "worker_index: %d, step%d cost = %f, total time cost = %f, average speed = %f, speed = %f"
-                % (fleet.worker_index(), step, cost_val[0], total_time,
-                   (step - 99) / total_time, 1 / (end_time - start_time)))
-        step += 1
-    if model.use_dali:
-        loader.reset()
+trainer = X.Trainer(place)
+trainer.fit(model, loader, epoch=10)

--- a/examples/vgg_app.py
+++ b/examples/vgg_app.py
@@ -58,5 +58,5 @@ optimizer = fleet.distributed_optimizer(optimizer, strategy=dist_strategy)
 optimizer.minimize(model.loss)
 
 place = fluid.CUDAPlace(int(os.environ.get('FLAGS_selected_gpus', 0)))
-trainer = X.Trainer(place)
+trainer = X.MultiGPUTrainer(place)
 trainer.fit(model, loader, epoch=10)

--- a/examples/vgg_app.py
+++ b/examples/vgg_app.py
@@ -37,7 +37,7 @@ fleet.init(role)
 model = X.applications.VGG16()
 
 loader = model.load_imagenet_from_file(
-    "/pathto/ImageNet/train.txt", data_layout='NCHW')
+    "/ssd2/lilong/ImageNet/train.txt", data_layout='NCHW')
 
 exec_strategy = fluid.ExecutionStrategy()
 dist_strategy = fleet.DistributedStrategy()
@@ -57,6 +57,5 @@ optimizer = fluid.optimizer.Momentum(
 optimizer = fleet.distributed_optimizer(optimizer, strategy=dist_strategy)
 optimizer.minimize(model.loss)
 
-place = fluid.CUDAPlace(int(os.environ.get('FLAGS_selected_gpus', 0)))
-trainer = X.MultiGPUTrainer(place)
+trainer = X.MultiGPUTrainer()
 trainer.fit(model, loader, epoch=10)

--- a/python/fleetx/__init__.py
+++ b/python/fleetx/__init__.py
@@ -17,3 +17,4 @@ from . import applications
 from .applications import *
 from . import dataset
 from .dataset import *
+from .applications.trainer import Trainer

--- a/python/fleetx/__init__.py
+++ b/python/fleetx/__init__.py
@@ -17,4 +17,6 @@ from . import applications
 from .applications import *
 from . import dataset
 from .dataset import *
-from .applications.trainer import Trainer
+from .applications.trainer import MultiGPUTrainer, CPUTrainer
+from . import utils
+from .utils import *

--- a/python/fleetx/applications/__init__.py
+++ b/python/fleetx/applications/__init__.py
@@ -13,3 +13,4 @@
 # limitations under the License.
 
 from model import *
+from util import *

--- a/python/fleetx/applications/model.py
+++ b/python/fleetx/applications/model.py
@@ -57,8 +57,8 @@ def download_model(fleet_path, model_name):
                 os.system(
                     'wget -P {} --no-check-certificate https://fleet.bj.bcebos.com/models/{}/{}.tar.gz'.
                     format(fleet_path, version, model_name))
-                os.system('tar -xf {}{}.tar.gz -C {}'.format(
-                    fleet_path, model_name, fleet_path))
+            os.system('tar -xf {}{}.tar.gz -C {}'.format(
+                fleet_path, model_name, fleet_path))
     else:
         time.sleep(3)
 

--- a/python/fleetx/applications/model.py
+++ b/python/fleetx/applications/model.py
@@ -165,9 +165,9 @@ class Transformer(ModelBase):
             shuffle=shuffle)
 
 
-class Bert_large(ModelBase):
+class BertLarge(ModelBase):
     def __init__(self):
-        super(Bert_large, self).__init__()
+        super(BertLarge, self).__init__()
         fleet_path = sysconfig.get_paths()["purelib"] + '/fleetx/applications/'
         model_name = 'bert_large'
         download_model(fleet_path, model_name)
@@ -195,9 +195,9 @@ class Bert_large(ModelBase):
             in_tokens=in_tokens)
 
 
-class Bert_base(ModelBase):
+class BertBase(ModelBase):
     def __init__(self):
-        super(Bert_base, self).__init__()
+        super(BertBase, self).__init__()
         fleet_path = sysconfig.get_paths()["purelib"] + '/fleetx/applications/'
         model_name = 'bert_base'
         download_model(fleet_path, model_name)
@@ -240,11 +240,11 @@ class MultiSlotCTR(ModelBase):
         self.checkpoints = checkpoints
         self.target = target
 
-    def load_multislot_from_file(self,
-                                 train_files_path,
-                                 sparse_feature_dim=1000001,
-                                 batch_size=1000,
-                                 shuffle=True):
+    def load_criteo_from_file(self,
+                              train_files_path,
+                              sparse_feature_dim=1000001,
+                              batch_size=1000,
+                              shuffle=True):
         return get_dataloader(
             self.inputs,
             train_files_path,

--- a/python/fleetx/applications/model.py
+++ b/python/fleetx/applications/model.py
@@ -19,6 +19,7 @@ from fleetx.dataset.image_dataset import image_dataloader_from_filelist
 from fleetx.dataset.bert_dataset import load_bert_dataset
 from fleetx.dataset.transformer_dataset import transformer_data_generator
 from fleetx.version import fleetx_version
+from fleetx.dataset.ctr_data_generator import get_dataloader
 
 
 class ModelBase(object):
@@ -221,3 +222,31 @@ class Bert_base(ModelBase):
             batch_size=batch_size,
             max_seq_len=max_seq_len,
             in_tokens=in_tokens)
+
+
+class MultiSlotCTR(ModelBase):
+    def __init__(self):
+        super(CTR, self).__init__()
+        fleet_path = sysconfig.get_paths()["purelib"] + '/fleetx/applications/'
+        model_name = 'ctr'
+        #        download_model(fleet_path, model_name)
+        inputs, loss, startup, main, unique_generator, checkpoints, target = load_program(
+            model_name)
+        self.startup_prog = startup
+        self.main_prog = main
+        self.inputs = inputs
+        self.loss = loss
+        self.checkpoints = checkpoints
+        self.target = target
+
+    def load_multislot_from_file(self,
+                                 train_files_path,
+                                 sparse_feature_dim=1000001,
+                                 batch_size=1000,
+                                 shuffle=True):
+        return get_dataloader(
+            model.inputs,
+            train_files_path,
+            sparse_feature_dim=sparse_feature_dim,
+            batch_size=batch_size,
+            shuffle=shuffle)

--- a/python/fleetx/applications/model.py
+++ b/python/fleetx/applications/model.py
@@ -46,6 +46,35 @@ class ModelBase(object):
     def main_program(self):
         return self.main_prog
 
+    def linear_warmup_decay(self, learning_rate, warmup_steps,
+                            num_train_steps):
+        """ Applies linear warmup of learning rate from 0 and decay to 0."""
+        with fluid.default_main_program()._lr_schedule_guard():
+            lr = fluid.layers.tensor.create_global_var(
+                shape=[1],
+                value=0.0,
+                dtype='float32',
+                persistable=True,
+                name="scheduled_learning_rate")
+
+            global_step = fluid.layers.learning_rate_scheduler._decay_step_counter(
+            )
+
+            with fluid.layers.control_flow.Switch() as switch:
+                with switch.case(global_step < warmup_steps):
+                    warmup_lr = learning_rate * (global_step / warmup_steps)
+                    fluid.layers.tensor.assign(warmup_lr, lr)
+                with switch.default():
+                    decayed_lr = fluid.layers.learning_rate_scheduler.polynomial_decay(
+                        learning_rate=learning_rate,
+                        decay_steps=num_train_steps,
+                        end_learning_rate=0.0,
+                        power=1.0,
+                        cycle=False)
+                    fluid.layers.tensor.assign(decayed_lr, lr)
+
+            return lr
+
 
 def download_model(fleet_path, model_name):
     version = fleetx_version.replace('-', '')

--- a/python/fleetx/applications/trainer.py
+++ b/python/fleetx/applications/trainer.py
@@ -1,0 +1,49 @@
+# Copyright (c) 2020 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import time
+import paddle
+import paddle.fluid as fluid
+import paddle.distributed.fleet as fleet
+
+
+class Trainer(object):
+    def __init__(self, place):
+        self.place = place
+
+    def fit(self, model, dataloader, epoch, use_dali=False, start_step=10):
+        """ run train program in one line, start step is the time to count speed."""
+        exe = fluid.Executor(self.place)
+        exe.run(fluid.default_startup_program())
+
+        for epoch_id in range(epoch):
+            total_time = 0
+            step = 0
+            for data in dataloader:
+                if step > start_step:
+                    start_time = time.time()
+                loss = exe.run(fluid.default_main_program(),
+                               feed=data,
+                               fetch_list=[model.loss.name])
+                if step > start_step:
+                    end_time = time.time()
+                    total_time += (end_time - start_time)
+                    print(
+                        "worker_index: %d, step%d, train_loss: %f, total time cost = %f, step per second: %f, speed: %f"
+                        % (fleet.worker_index(), step, loss[0], total_time,
+                           (step - start_step) / total_time,
+                           1 / (end_time - start_time)))
+                step += 1
+            if use_dali:
+                dataloader.reset()

--- a/python/fleetx/applications/trainer.py
+++ b/python/fleetx/applications/trainer.py
@@ -11,7 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-
+import os
 import time
 import paddle
 import paddle.fluid as fluid
@@ -19,11 +19,49 @@ import paddle.distributed.fleet as fleet
 
 
 class Trainer(object):
-    def __init__(self, place):
-        self.place = place
+    def __init__(self):
+        self.place = None
+
+
+class CPUTrainer(Trainer):
+    def __init__(self):
+        super(CPUTrainer, self).__init__()
+
+    def fit(self, model, dataloader, epoch, start_step=10):
+        fleet.init_worker()
+        self.place = fluid.CPUPlace()
+        exe = fluid.Executor(self.place)
+        exe.run(fluid.default_startup_program())
+
+        for epoch_id in range(epoch):
+            total_time = 0
+            step = 0
+            for data in dataloader:
+                if step > start_step:
+                    start_time = time.time()
+                loss = exe.run(fluid.default_main_program(),
+                               feed=data,
+                               fetch_list=[model.loss.name])
+                if step > start_step:
+                    end_time = time.time()
+                    total_time += (end_time - start_time)
+                    print(
+                        "worker_index: %d, step%d, train_loss: %f, total time cost = %f, step per second: %f, speed: %f"
+                        % (fleet.worker_index(), step, loss[0], total_time,
+                           (step - start_step) / total_time,
+                           1 / (end_time - start_time)))
+                step += 1
+
+        fleet.stop_worker()
+
+
+class MultiGPUTrainer(Trainer):
+    def __init__(self):
+        super(MultiGPUTrainer, self).__init__()
 
     def fit(self, model, dataloader, epoch, use_dali=False, start_step=10):
-        """ run train program in one line, start step is the time to count speed."""
+        self.place = fluid.CUDAPlace(
+            int(os.environ.get('FLAGS_selected_gpus', 0)))
         exe = fluid.Executor(self.place)
         exe.run(fluid.default_startup_program())
 

--- a/python/fleetx/applications/util.py
+++ b/python/fleetx/applications/util.py
@@ -168,32 +168,3 @@ def save_program(main_prog,
                 fout.write("%s\n" % ckpt.name)
     with open(program_path + '/target', 'w') as fout:
         fout.write(target.name)
-
-
-def linear_warmup_decay(learning_rate, warmup_steps, num_train_steps):
-    """ Applies linear warmup of learning rate from 0 and decay to 0."""
-    with fluid.default_main_program()._lr_schedule_guard():
-        lr = fluid.layers.tensor.create_global_var(
-            shape=[1],
-            value=0.0,
-            dtype='float32',
-            persistable=True,
-            name="scheduled_learning_rate")
-
-        global_step = fluid.layers.learning_rate_scheduler._decay_step_counter(
-        )
-
-        with fluid.layers.control_flow.Switch() as switch:
-            with switch.case(global_step < warmup_steps):
-                warmup_lr = learning_rate * (global_step / warmup_steps)
-                fluid.layers.tensor.assign(warmup_lr, lr)
-            with switch.default():
-                decayed_lr = fluid.layers.learning_rate_scheduler.polynomial_decay(
-                    learning_rate=learning_rate,
-                    decay_steps=num_train_steps,
-                    end_learning_rate=0.0,
-                    power=1.0,
-                    cycle=False)
-                fluid.layers.tensor.assign(decayed_lr, lr)
-
-        return lr

--- a/python/fleetx/applications/util.py
+++ b/python/fleetx/applications/util.py
@@ -168,3 +168,32 @@ def save_program(main_prog,
                 fout.write("%s\n" % ckpt.name)
     with open(program_path + '/target', 'w') as fout:
         fout.write(target.name)
+
+
+def linear_warmup_decay(self, learning_rate, warmup_steps, num_train_steps):
+    """ Applies linear warmup of learning rate from 0 and decay to 0."""
+    with fluid.default_main_program()._lr_schedule_guard():
+        lr = fluid.layers.tensor.create_global_var(
+            shape=[1],
+            value=0.0,
+            dtype='float32',
+            persistable=True,
+            name="scheduled_learning_rate")
+
+        global_step = fluid.layers.learning_rate_scheduler._decay_step_counter(
+        )
+
+        with fluid.layers.control_flow.Switch() as switch:
+            with switch.case(global_step < warmup_steps):
+                warmup_lr = learning_rate * (global_step / warmup_steps)
+                fluid.layers.tensor.assign(warmup_lr, lr)
+            with switch.default():
+                decayed_lr = fluid.layers.learning_rate_scheduler.polynomial_decay(
+                    learning_rate=learning_rate,
+                    decay_steps=num_train_steps,
+                    end_learning_rate=0.0,
+                    power=1.0,
+                    cycle=False)
+                fluid.layers.tensor.assign(decayed_lr, lr)
+
+        return lr

--- a/python/fleetx/applications/util.py
+++ b/python/fleetx/applications/util.py
@@ -170,7 +170,7 @@ def save_program(main_prog,
         fout.write(target.name)
 
 
-def linear_warmup_decay(self, learning_rate, warmup_steps, num_train_steps):
+def linear_warmup_decay(learning_rate, warmup_steps, num_train_steps):
     """ Applies linear warmup of learning rate from 0 and decay to 0."""
     with fluid.default_main_program()._lr_schedule_guard():
         lr = fluid.layers.tensor.create_global_var(

--- a/python/fleetx/dataset/ctr_data_generator.py
+++ b/python/fleetx/dataset/ctr_data_generator.py
@@ -1,0 +1,99 @@
+#!/usr/bin/python
+# Copyright (c) 2019 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# There are 13 integer features and 26 categorical features
+import paddle
+import paddle.fluid as fluid
+import paddle.distributed.fleet as fleet
+
+continous_features = range(1, 14)
+categorial_features = range(14, 40)
+continous_clip = [20, 600, 100, 50, 64000, 500, 100, 50, 500, 10, 10, 10, 50]
+
+
+def get_dataloader(inputs,
+                   train_files_path,
+                   sparse_feature_dim,
+                   batch_size,
+                   shuffle=True):
+    file_list = [
+        str(train_files_path) + "/%s" % x for x in os.listdir(train_files_path)
+    ]
+
+    loader = fluid.io.DataLoader.from_generator(
+        feed_list=inputs, capacity=64, use_double_buffer=True, iterable=True)
+    train_generator = CriteoDataset(sparse_feature_dim)
+    reader = train_generator.train(file_list,
+                                   fleet.worker_num(), fleet.worker_index())
+    if shuffle:
+        reader = paddle.batch(
+            paddle.reader.shuffle(
+                reader, buf_size=batch_size * 100),
+            batch_size=batch_size)
+    else:
+        reader = paddle.batch(reader, batch_size=batch_size)
+    places = fluid.CPUPlace()
+    loader.set_sample_list_generator(train_reader, places)
+    return loader
+
+
+class CriteoDataset(object):
+    def __init__(self, sparse_feature_dim):
+        self.cont_min_ = [0, -3, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0]
+        self.cont_max_ = [
+            20, 600, 100, 50, 64000, 500, 100, 50, 500, 10, 10, 10, 50
+        ]
+        self.cont_diff_ = [
+            20, 603, 100, 50, 64000, 500, 100, 50, 500, 10, 10, 10, 50
+        ]
+        self.hash_dim_ = sparse_feature_dim
+        # here, training data are lines with line_index < train_idx_
+        self.train_idx_ = 41256555
+        self.continuous_range_ = range(1, 14)
+        self.categorical_range_ = range(14, 40)
+
+    def _reader_creator(self, file_list, is_train, trainer_num, trainer_id):
+        def reader():
+            for file in file_list:
+                with open(file, 'r') as f:
+                    line_idx = 0
+                    for line in f:
+                        line_idx += 1
+                        features = line.rstrip('\n').split('\t')
+                        dense_feature = []
+                        sparse_feature = []
+                        for idx in self.continuous_range_:
+                            if features[idx] == '':
+                                dense_feature.append(0.0)
+                            else:
+                                dense_feature.append(
+                                    (float(features[idx]) -
+                                     self.cont_min_[idx - 1]) /
+                                    self.cont_diff_[idx - 1])
+                        for idx in self.categorical_range_:
+                            sparse_feature.append([
+                                hash(str(idx) + features[idx]) % self.hash_dim_
+                            ])
+
+                        label = [int(features[0])]
+                        yield [dense_feature] + sparse_feature + [label]
+
+        return reader
+
+    def train(self, file_list, trainer_num, trainer_id):
+        return self._reader_creator(file_list, True, trainer_num, trainer_id)
+
+    def test(self, file_list):
+        return self._reader_creator(file_list, False, 1, 0)

--- a/python/fleetx/dataset/ctr_data_generator.py
+++ b/python/fleetx/dataset/ctr_data_generator.py
@@ -14,6 +14,7 @@
 # limitations under the License.
 
 # There are 13 integer features and 26 categorical features
+import os
 import paddle
 import paddle.fluid as fluid
 import paddle.distributed.fleet as fleet
@@ -45,7 +46,7 @@ def get_dataloader(inputs,
     else:
         reader = paddle.batch(reader, batch_size=batch_size)
     places = fluid.CPUPlace()
-    loader.set_sample_list_generator(train_reader, places)
+    loader.set_sample_list_generator(reader, places)
     return loader
 
 

--- a/python/fleetx/utils/__init__.py
+++ b/python/fleetx/utils/__init__.py
@@ -1,6 +1,6 @@
-# Copyright (c) 2020  PaddlePaddle Authors. All Rights Reserved.
+# Copyright (c) 2020 PaddlePaddle Authors. All Rights Reserved.
 #
-# Licensed under the Apache License, Version 2.0 (the "License"
+# Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
@@ -11,6 +11,5 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-""" FleetX version string """
-fleetx_version = "0.0.2"
-module_proto_version = "0.0.2"
+
+from lr_strategy import *

--- a/python/fleetx/utils/lr_strategy.py
+++ b/python/fleetx/utils/lr_strategy.py
@@ -1,0 +1,44 @@
+# Copyright (c) 2020 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import paddle.fluid as fluid
+
+
+def linear_warmup_decay(learning_rate, warmup_steps, num_train_steps):
+    """ Applies linear warmup of learning rate from 0 and decay to 0."""
+    with fluid.default_main_program()._lr_schedule_guard():
+        lr = fluid.layers.tensor.create_global_var(
+            shape=[1],
+            value=0.0,
+            dtype='float32',
+            persistable=True,
+            name="scheduled_learning_rate")
+
+        global_step = fluid.layers.learning_rate_scheduler._decay_step_counter(
+        )
+
+        with fluid.layers.control_flow.Switch() as switch:
+            with switch.case(global_step < warmup_steps):
+                warmup_lr = learning_rate * (global_step / warmup_steps)
+                fluid.layers.tensor.assign(warmup_lr, lr)
+            with switch.default():
+                decayed_lr = fluid.layers.learning_rate_scheduler.polynomial_decay(
+                    learning_rate=learning_rate,
+                    decay_steps=num_train_steps,
+                    end_learning_rate=0.0,
+                    power=1.0,
+                    cycle=False)
+                fluid.layers.tensor.assign(decayed_lr, lr)
+
+        return lr

--- a/python/fleetx/version.py
+++ b/python/fleetx/version.py
@@ -12,5 +12,5 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 """ FleetX version string """
-fleetx_version = "0.0.2"
-module_proto_version = "0.0.2"
+fleetx_version = "0.0.3"
+module_proto_version = "0.0.3"

--- a/python/fleetx/version.py
+++ b/python/fleetx/version.py
@@ -12,5 +12,5 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 """ FleetX version string """
-fleetx_version = "0.0.0"
-module_proto_version = "0.0.0"
+fleetx_version = "0.0.1"
+module_proto_version = "0.0.1"

--- a/python/setup.py
+++ b/python/setup.py
@@ -40,12 +40,14 @@ packages = [
     'fleetx',
     'fleetx.applications',
     'fleetx.dataset',
+    'fleetx.utils',
 ]
 
 package_dir = {
     'fleetx': './fleetx',
     'fleetx.applications': './fleetx/applications',
-    'fleetx.dataset': './fleetx/dataset'
+    'fleetx.dataset': './fleetx/dataset',
+    'fleetx.utils': './fleetx/utils'
 }
 
 setup(


### PR DESCRIPTION
- Add fleet cpu example based on MultiSlotCTR model and support sync/async/geosgd strategies

- Add lr scheduler for users to warm-up or decay learning rate in one code.