### PR TITLE
add files to add file_dir

### DIFF
--- a/python/fleetx/utils/submitter.py
+++ b/python/fleetx/utils/submitter.py
@@ -40,9 +40,9 @@ class PaddleCloudSubmitter(Submitter):
                           "--job-name {} " \
                           "--start-cmd 'sh start_job.sh' " \
                           "--job-conf config.ini " \
-                          "--files start_job.sh{} " \
                           "--k8s-trainers {} {} " \
                           "--k8s-cpu-cores 35 " \
+                          "--file-dir {} " \
                           "--is-auto-over-sell {}"
 
     def get_start_job(self, yml_cfg):
@@ -105,21 +105,20 @@ class PaddleCloudSubmitter(Submitter):
         assert "group_name" in cfg, "group_name should be configured"
         group_name = cfg["group_name"]
         self.get_start_job(cfg)
-        if "upload_files" in cfg:
-            file_list = cfg['upload_files']
+        file_dir = "./"
+        if "file_dir" in cfg:
+            file_dir = cfg["file_dir"]
         if "over_sell" in cfg:
             over_sell = cfg['over_sell']
         else:
             over_sell = 1
-        job_script = ''
-        for item in file_list:
-            job_script += " " + item
         distribute_suffix = " --k8s-not-local --distribute-job-type NCCL2" \
                             if int(num_trainers) > 1 else ""
         pcloud_submit_cmd = self.submit_str.format(
             server, port, image_addr, cluster_name, group_name, num_cards,
             "{}_N{}C{}".format(job_prefix, num_trainers, num_cards),
-            job_script, num_trainers, distribute_suffix, over_sell)
+            num_trainers, distribute_suffix, 
+            file_dir, over_sell)
         print(pcloud_submit_cmd)
         os.system(pcloud_submit_cmd)
 


### PR DESCRIPTION
if you are using fleetsub to submit a job, the only thing you need to code beyond your training script is the `submit.yaml` file

Here is an example after this PR is merged.

``` shell
num_trainers: 2
num_cards: 8
job_prefix: bert_huge_pretraining
image_addr: ${image_addr:-"registry.baidu.com/paddlepaddle-public/paddle_ubuntu1604:cuda10.0-cudnn7-dev"}
cluster_name: v100-32-0-cluster
group_name: xxx-0-yq01-k8s-gpu-v100-8
server: paddlecloud.xx-int.com
log_fs_name: "afs://xx.xx.xx.xx:9902"
log_fs_ugi: "xx,xxx"
log_output_path: "xxx"
file_dir: "./"

whl_install_commands:
  - wget --no-check-certificate http://xx.xx.xx.xx:8282/fleet_x-0.0.4-py2-none-any.whl
  - pip install fleet_x-0.0.4-py2-none-any.whl --index-url=http://pip.baidu.com/pypi/simple --trusted-host pip.baidu.com
  - wget --no-check-certificate http://xx.xx.xx.xx:8113/paddlepaddle_gpu-0.0.0-cp27-cp27mu-linux_x86_64.whl
  - pip install paddlepaddle_gpu-0.0.0-cp27-cp27mu-linux_x86_64.whl --index-url=http://pip.baidu.com/pypi/simple --trusted-host pip.baidu.com

commands:
  - cd paddle_debug_tools
  - python setup.py install
  - cd ..
  - fleetrun bert_app.py --download_config=bert.yaml
```

``` shell
fleetsub -f submit.yaml
```