### PR TITLE
change old DataLoader API to new DataLoader API

### DIFF
--- a/python/fleetx/dataset/bert_dataset.py
+++ b/python/fleetx/dataset/bert_dataset.py
@@ -37,7 +37,7 @@ def load_bert_dataset(data_dir,
                       shuffle=True,
                       generate_neg_sample=True,
                       voc_size=21128):
-    data_loader = fluid.io.DataLoader.from_generator(
+    data_loader = paddle.io.DataLoader.from_generator(
         feed_list=inputs, capacity=70, iterable=True)
     if lang == 'en':
         data_reader = DataReaderV2(

--- a/python/fleetx/dataset/ctr_data_generator.py
+++ b/python/fleetx/dataset/ctr_data_generator.py
@@ -33,7 +33,7 @@ def get_dataloader(inputs,
         str(train_files_path) + "/%s" % x for x in os.listdir(train_files_path)
     ]
 
-    loader = fluid.io.DataLoader.from_generator(
+    loader = paddle.io.DataLoader.from_generator(
         feed_list=inputs, capacity=64, use_double_buffer=True, iterable=True)
     train_generator = CriteoDataset(sparse_feature_dim)
     reader = train_generator.train(file_list,

--- a/python/fleetx/dataset/image_dataset.py
+++ b/python/fleetx/dataset/image_dataset.py
@@ -177,14 +177,14 @@ def create_data_loader(inputs, phase, use_mixup, data_layout='NHWC'):
         feed_lam = fluid.data(
             name="feed_lam", shape=[None, 1], dtype="float32", lod_level=0)
 
-        data_loader = fluid.io.DataLoader.from_generator(
+        data_loader = paddle.io.DataLoader.from_generator(
             feed_list=[feed_image, feed_y_a, feed_y_b, feed_lam],
             capacity=64,
             use_double_buffer=True,
             iterable=True)
         return data_loader
     else:
-        data_loader = fluid.io.DataLoader.from_generator(
+        data_loader = paddle.io.DataLoader.from_generator(
             feed_list=[feed_image, feed_label],
             capacity=64,
             use_double_buffer=True,

--- a/python/fleetx/dataset/transformer_dataset.py
+++ b/python/fleetx/dataset/transformer_dataset.py
@@ -40,7 +40,7 @@ def transformer_data_generator(src_vocab_fpath,
                                unk_mark="<unk>",
                                max_length=256,
                                n_head=8):
-    data_loader = fluid.io.DataLoader.from_generator(
+    data_loader = paddle.io.DataLoader.from_generator(
         feed_list=inputs, capacity=70, iterable=True)
     processor = DataProcessor(
         train_filelist=train_filelist,


### PR DESCRIPTION
fix Dataloader API, change fluid.io.DataLoader to paddle.io.DataLoader,  because of throwing SIGABORT when using fluid.io.DataLoader.
![image](https://user-images.githubusercontent.com/12137504/103271719-f3bd0b80-49f5-11eb-8ccc-944552e19cce.png)
