### PR TITLE
add link for paddle collective benchmark

### DIFF
--- a/docs/source/paddle_fleet_rst/collective/collective_benchmark.rst
+++ b/docs/source/paddle_fleet_rst/collective/collective_benchmark.rst
@@ -1,4 +1,4 @@
 性能基准
 ------------------
 
-请访问 `飞桨Perf Repo <https://github.com/PaddlePaddle/Perf>`_ 获取飞桨性能基准数据。
+请访问飞桨 `Perf Repo <https://github.com/PaddlePaddle/Perf>`_ 获取飞桨性能基准数据。

--- a/docs/source/paddle_fleet_rst/collective/collective_benchmark.rst
+++ b/docs/source/paddle_fleet_rst/collective/collective_benchmark.rst
@@ -1,4 +1,4 @@
 性能基准
 ------------------
 
--  TBA (李龙)
+请访问 `飞桨Perf Repo <https://github.com/PaddlePaddle/Perf>`_ 获取飞桨性能基准数据。


### PR DESCRIPTION
add repo link for paddle benchmark (collective)
![image](https://user-images.githubusercontent.com/6737864/103863190-5cde0680-50fb-11eb-9b34-d763f9c9a077.png)
