### PR TITLE
fix end of training dataloader reset bug

### DIFF
--- a/examples/hybrid_parallelism/run_pretraining.py
+++ b/examples/hybrid_parallelism/run_pretraining.py
@@ -467,6 +467,7 @@ def train(args):
                 log.debug("saving final models to {}".format(save_path))
                 log.debug("end of training, total steps: {}".format(steps))
                 break
+    data_loader.reset()
 
 
 if __name__ == "__main__":

--- a/examples/hybrid_parallelism/run_pretraining.py
+++ b/examples/hybrid_parallelism/run_pretraining.py
@@ -467,7 +467,7 @@ def train(args):
                 log.debug("saving final models to {}".format(save_path))
                 log.debug("end of training, total steps: {}".format(steps))
                 break
-    data_loader.reset()
+        data_loader.reset()
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
```
yq01-sys-hic-k8s-v100-box-a225-0562:4502:4632 [0] NCCL INFO Launch mode Parallel
yq01-sys-hic-k8s-v100-box-a225-0562:4502:4632 [0] NCCL INFO Launch mode Parallel
[DEBUG] 2021-07-07 20:29:25,512 [run_pretraining.py:  459]:     saving models to output/gpt3-test_0/step_10
[DEBUG] 2021-07-07 20:29:29,302 [run_pretraining.py:  467]:     saving final models to output/gpt3-test_0/final_step_11
[DEBUG] 2021-07-07 20:29:29,303 [run_pretraining.py:  468]:     end of training, total steps: 11
I0707 20:29:29.466617  4502 reader.h:164] ~ReaderHolder
I0707 20:29:29.466778  4502 reader.h:164] ~ReaderHolder
I0707 20:29:29.466785  4502 buffered_reader.cc:22] ~BufferedReader
I0707 20:29:29.466794  4502 lod_tensor_blocking_queue.h:59] LoDTensorBlockingQueue close
I0707 20:29:29.466797  4502 blocking_queue.h:132] close queue
I0707 20:29:29.466919  4502 reader.cc:76] ~DecoratedReader
I0707 20:29:29.466924  4502 lod_tensor_blocking_queue.h:59] LoDTensorBlockingQueue close
I0707 20:29:29.466928  4502 blocking_queue.h:132] close queue
I0707 20:29:29.466931  4502 lod_tensor_blocking_queue.h:59] LoDTensorBlockingQueue close
I0707 20:29:29.466934  4502 blocking_queue.h:132] close queue
terminate called without an active exception


--------------------------------------
C++ Traceback (most recent call last):
--------------------------------------
0   paddle::framework::SignalHandle(char const*, int)
1   paddle::platform::GetCurrentTraceBackString[abi:cxx11]()

----------------------
Error Message Summary:
----------------------
FatalError: `Process abort signal` is detected by the operating system.
  [TimeInfo: *** Aborted at 1625660969 (unix time) try "date -d @1625660969" if you are using GNU date ***]
  [SignalInfo: *** SIGABRT (@0x1196) received by PID 4502 (TID 0x7f5b8d5fe700) from PID 4502 ***]
```