### PR TITLE
update recompte interface.

### DIFF
--- a/fleetx/models/gpt_model/modeling_hybrid.py
+++ b/fleetx/models/gpt_model/modeling_hybrid.py
@@ -28,7 +28,7 @@ import paddle.incubate as incubate
 from paddle.distributed import fleet
 from paddle.distributed.fleet.meta_parallel import get_rng_state_tracker
 from paddle.distributed.fleet.meta_parallel import LayerDesc, PipelineLayer, SharedLayerDesc
-from paddle.distributed.fleet.utils import recompute
+from paddle.distributed.fleet import recompute
 import sys
 from .config import configurable
 
@@ -889,8 +889,11 @@ class GPTForPretrainingPipe(PipelineLayer):
             topology=topology,
             seg_method="layer:TransformerDecoderLayer",
             recompute_interval=recompute_interval,
-            recompute_partition=False,
-            recompute_offload=False)
+            recompute_ctx={
+                "mp_group": fleet.fleet._hcg.get_model_parallel_group(),
+                "offload": False,
+                "partition": False
+            })
 
     @classmethod
     def from_config(cls, cfg):


### PR DESCRIPTION
1、the PipelineLayer API has been changed for recompute,  use 'recompute_ctx'(dict)  parameter to represent  the context of recompute, the dict contains 'mp_group', 'offload', and 'partition' keys.

2、we recommend to use recompute for single card from the dir 'paddle.distributed.fleet'.