### PR TITLE
bugfix of gpt finetune for fuse_attn_qkv

### DIFF
--- a/ppfleetx/configs/nlp/gpt/finetune_gpt_345M_single_card_glue.yaml
+++ b/ppfleetx/configs/nlp/gpt/finetune_gpt_345M_single_card_glue.yaml
@@ -28,6 +28,7 @@ Model:
   name: "GPT"
   num_classes: 2
   pretrained: './ckpt/PaddleFleetX_GPT_345M_220826/model'
+  fuse_attn_qkv: True
   fused_linear: False
   vocab_size: 50304
   hidden_size: 1024


### PR DESCRIPTION
由于 gpt 组网中 MultiHeadAttention 的 `fuse=True` 被 [#800](https://github.com/PaddlePaddle/PaddleFleetX/commit/a8401cab26c59a82f39ca48db38332bcf61b94d9) 修改成了 `fuse_attn_qkv=False`，导致默认行为不一致，加载 checkpoint 不正确，最终导致 gpt glue benchmark finetune 的精度对不上 readme 中的精度。