### PR TITLE
Fix CLIP logit_scale clip behavior

### DIFF
--- a/ppfleetx/models/multimodal_model/clip/modeling.py
+++ b/ppfleetx/models/multimodal_model/clip/modeling.py
@@ -316,7 +316,8 @@ class CLIP(nn.Layer):
         return x
 
     def clip_logit_scale(self):
-        self.logit_scale.clip(-4.6, 4.6)
+        logit_scale_buffer = self.logit_scale.clip(-4.6, 4.6)
+        logit_scale_buffer._share_buffer_to(self.logit_scale)
 
     def forward(self, image, text, is_train=True):
         image_features = self.encode_image(image)


### PR DESCRIPTION
背景：CLIP logit scale 在进行裁剪时，需要添加 _share_buffer_to 方法才可以生效。
将 `self.logit_scale.clip(-4.6, 4.6)` 改为：
```
logit_scale_buffer = self.logit_scale.clip(-4.6, 4.6)
logit_scale_buffer._share_buffer_to(self.logit_scale)
```
相关 Issue 详见：
https://github.com/PaddlePaddle/PASSL/issues/125、
https://github.com/PaddlePaddle/Paddle/issues/43710
