### PR TITLE
Optimize ViT training performance

### DIFF
--- a/ppfleetx/models/vision_model/layers/attention.py
+++ b/ppfleetx/models/vision_model/layers/attention.py
@@ -15,6 +15,7 @@
 import paddle
 import paddle.nn as nn
 import paddle.nn.functional as F
+from paddle.fluid import layers
 from .initializer import xavier_uniform_, zeros_
 
 
@@ -49,7 +50,7 @@ class ViTAttention(nn.Layer):
                                    self.num_heads)).transpose((2, 0, 3, 1, 4))
         q, k, v = qkv[0], qkv[1], qkv[2]
 
-        attn = (q.matmul(k.transpose((0, 1, 3, 2)))) * self.scale
+        attn = layers.matmul(q, k, transpose_y=True, alpha=self.scale)
         attn = nn.functional.softmax(attn, axis=-1)
         attn = self.attn_drop(attn)
 

--- a/tools/train.py
+++ b/tools/train.py
@@ -20,6 +20,7 @@ import os
 import sys
 import copy
 
+import paddle
 from paddle.distributed import fleet
 import paddle.distributed as dist
 
@@ -32,7 +33,16 @@ from ppfleetx.data import build_dataloader
 from ppfleetx.models import build_module
 from ppfleetx.core import EagerEngine
 
+
+def set_default_flags(flags):
+    for flag_name, flag_value in flags.items():
+        if os.getenv(flag_name) is None:
+            paddle.set_flags({flag_name: flag_value})
+
+
 if __name__ == "__main__":
+    set_default_flags({'FLAGS_enable_cublas_tensor_op_math': True, })
+
     args = config.parse_args()
     cfg = config.get_config(args.config, overrides=args.override, show=False)
 


### PR DESCRIPTION
ViT-B16-384-Finetune performance improvement (N1C8, no gradient accumulation, local_batch_size=16, unit: images/sec ):

| Baseline | FusedMatmulScale | FusedMatmulScale + FLAGS_enable_cublas_tensor_op_math |
|---|---|---|
| 792 | 848 (+7%) | 874 (+10%) |