### PR TITLE
update past_length for FusedMultiTransformer fusion

### DIFF
--- a/ppfleetx/models/language_model/gpt/auto/auto_model.py
+++ b/ppfleetx/models/language_model/gpt/auto/auto_model.py
@@ -549,7 +549,7 @@ class GPTModelAuto(nn.Layer):
         if position_ids is None:
             past_length = 0
             if cache is not None:
-                past_length = paddle.shape(cache[0].k)[-2]
+                past_length = paddle.shape(attention_mask)[-1] - 1
             position_ids = paddle.arange(
                 past_length,
                 paddle.shape(input_ids)[-1] + past_length,

--- a/ppfleetx/models/language_model/gpt/dygraph/hybrid_model.py
+++ b/ppfleetx/models/language_model/gpt/dygraph/hybrid_model.py
@@ -764,7 +764,7 @@ class GPTModelHybrid(nn.Layer):
         if position_ids is None:
             past_length = 0
             if cache is not None:
-                past_length = paddle.shape(cache[0].k)[-2]
+                past_length = paddle.shape(attention_mask)[-1] - 1
             position_ids = paddle.arange(
                 past_length,
                 paddle.shape(input_ids)[-1] + past_length,

--- a/ppfleetx/models/language_model/gpt/dygraph/single_model.py
+++ b/ppfleetx/models/language_model/gpt/dygraph/single_model.py
@@ -618,7 +618,7 @@ class GPTModel(nn.Layer):
         if position_ids is None:
             past_length = 0
             if cache is not None:
-                past_length = paddle.shape(cache[0].k)[-2]
+                past_length = paddle.shape(attention_mask)[-1] - 1
             position_ids = paddle.arange(
                 past_length,
                 paddle.shape(input_ids)[-1] + past_length,


### PR DESCRIPTION
**update past_length for FusedMultiTransformer fusion**
`FuseMultTransformer` fusion pass will fuse `multi-head attention` and `feed forward` into `FuseMultTransformer`, `Cache KV` nodes will be deleted, so `past_length` cannot be get from `Cache KV`, change to get from `attention_mask`