### PR TITLE
Set flag FLAGS_enable_cublas_tensor_op_math True in default.

### DIFF
--- a/tools/train.py
+++ b/tools/train.py
@@ -42,6 +42,7 @@ def set_default_flags(flags):
 
 
 if __name__ == "__main__":
+    set_default_flags({'FLAGS_enable_cublas_tensor_op_math': True, })
     args = config.parse_args()
     cfg = config.get_config(args.config, overrides=args.override, show=False)
 


### PR DESCRIPTION
When FP32 and FP16 model runs on A100 machine, it can be accelerated using TensorCore. Although NVIDIA declares that fp32 computation will be transferred to TensorCore automatically on A100, we detect that it's not the case. As a result, we set flag FLAGS_enable_cublas_tensor_op_math True in default manually.