### PR TITLE
Replace `_reduce_scatter_base` with `stream.reduce_scatter`

### DIFF
--- a/ppfleetx/distributed/protein_folding/dap.py
+++ b/ppfleetx/distributed/protein_folding/dap.py
@@ -160,9 +160,8 @@ def _reduce_scatter(tensor, sync_op=True):
     tensor_shape[0] = divide(tensor_shape[0], group.nranks)
     output = paddle.zeros(tensor_shape, tensor.dtype)
     output.stop_gradient = tensor.stop_gradient
-    task = group.process_group._reduce_scatter_base(
-        output, tensor, paddle.fluid.core.ReduceOp.SUM)
-    task.wait()
+    dist.stream.reduce_scatter(
+        output, tensor, op=dist.ReduceOp.SUM, group=group, sync_op=True)
     return output
 
 

--- a/ppfleetx/models/language_model/gpt/dygraph/sequence_parallel_utils.py
+++ b/ppfleetx/models/language_model/gpt/dygraph/sequence_parallel_utils.py
@@ -74,7 +74,8 @@ def reduce_scatter(input):
             input.shape[0], parallelism)
     output_shape[0] = output_shape[0] // parallelism
     output = paddle.empty(shape=output_shape, dtype=input.dtype)
-    group.process_group._reduce_scatter_base(output, input).wait()
+    dist.stream.reduce_scatter(
+        output, input, op=dist.ReduceOp.SUM, group=group, sync_op=True)
     return output
 
 
@@ -353,7 +354,7 @@ class RowSequenceParallelLinear(Layer):
 
         self.weight.is_distributed = True if self.is_mp else False
 
-        # if sequence parallel is true, 
+        # if sequence parallel is true,
         # register hook to all_reduce gradient of weight and bias
         if has_bias:
             self.bias = self.create_parameter(

--- a/ppfleetx/models/language_model/gpt/dygraph/sequence_parallel_utils.py
+++ b/ppfleetx/models/language_model/gpt/dygraph/sequence_parallel_utils.py
@@ -16,6 +16,7 @@
 
 import paddle
 from paddle import framework
+from paddle import distributed as dist
 from paddle.nn import functional as F
 from paddle.autograd import PyLayer
 from paddle.fluid import core


### PR DESCRIPTION
Paddle 主仓库集合通信接口重构，移除了 pybind 中的 `_reduce_scatter_base`，导致依赖该内部实现的部分出现错误，因此将仓库中的 `_reduce_scatter_base` 替换为对外提供的上层通信接口。
对应的主仓库 pr：https://github.com/PaddlePaddle/Paddle/pull/47740