### PR TITLE
[Multi-Device] xpu

### DIFF
--- a/ppfleetx/models/language_model/gpt/dygraph/hybrid_model.py
+++ b/ppfleetx/models/language_model/gpt/dygraph/hybrid_model.py
@@ -37,7 +37,7 @@ from .sequence_parallel_utils import ScatterOp, GatherOp, \
 
 from ppfleetx.distributed.moe import MoELayer
 from ppfleetx.distributed.apis import env
-
+from ppfleetx.utils.log import logger
 
 def get_attr(layer, name):
     if getattr(layer, name, None) is not None:
@@ -778,13 +778,16 @@ class GPTModelHybrid(nn.Layer):
         embedding_output = self.embeddings(
             input_ids=input_ids, position_ids=position_ids)
 
-        if self.training == False:
+        # fused_soiftmax_with_triangular is only suppported on GPU/DCU.
+        # If on XPU, we use user defined mask and non-fused softmax.
+        if self.training == False or not paddle.is_compiled_with_cuda():
             # TODO, use registered buffer
             causal_mask = paddle.tensor.triu(
                 paddle.ones(
                     (paddle.shape(input_ids)[-1], paddle.shape(input_ids)[-1]))
                 * -1e4,
                 diagonal=1)
+            logger.debug(f"attention mask: {attention_mask}")
             if attention_mask is not None:
                 if len(attention_mask.shape) == 2:
                     attention_mask = attention_mask[:, None, None, :]
@@ -797,7 +800,7 @@ class GPTModelHybrid(nn.Layer):
         encoder_outputs = self.decoder(
             embedding_output,
             memory=None,
-            tgt_mask=None if self.training else
+            tgt_mask=None if self.training and paddle.is_compiled_with_cuda() else
             attention_mask,  # use softmax_mask_fuse_upper_triangle
             use_cache=use_cache,
             cache=cache)

--- a/ppfleetx/models/language_model/gpt/dygraph/hybrid_model.py
+++ b/ppfleetx/models/language_model/gpt/dygraph/hybrid_model.py
@@ -779,7 +779,7 @@ class GPTModelHybrid(nn.Layer):
             input_ids=input_ids, position_ids=position_ids)
 
         # fused_soiftmax_with_triangular is only suppported on GPU/DCU.
-        # If on XPU, we use user defined mask and non-fused softmax.
+        # If on non-GPU devices, we use user defined mask and non-fused softmax.
         if self.training == False or not paddle.is_compiled_with_cuda():
             # TODO, use registered buffer
             causal_mask = paddle.tensor.triu(

--- a/ppfleetx/models/language_model/gpt/dygraph/single_model.py
+++ b/ppfleetx/models/language_model/gpt/dygraph/single_model.py
@@ -630,7 +630,9 @@ class GPTModel(nn.Layer):
         embedding_output = self.embeddings(
             input_ids=input_ids, position_ids=position_ids)
 
-        if self.training == False:
+        # fused_soiftmax_with_triangular is only suppported on GPU/DCU.
+        # If on non-GPU devices, we use user defined mask and non-fused softmax.
+        if self.training == False or not paddle.is_compiled_with_cuda():
             # TODO, use registered buffer
             causal_mask = paddle.tensor.triu(
                 paddle.ones(
@@ -649,7 +651,7 @@ class GPTModel(nn.Layer):
         encoder_outputs = self.decoder(
             embedding_output,
             memory=None,
-            tgt_mask=None if self.training else
+            tgt_mask=None if self.training and paddle.is_compiled_with_cuda() else
             attention_mask,  # use softmax_mask_fuse_upper_triangle
             use_cache=use_cache,
             cache=cache)

--- a/ppfleetx/utils/check.py
+++ b/ppfleetx/utils/check.py
@@ -22,7 +22,7 @@ import sys
 import paddle
 from paddle import is_compiled_with_cuda
 from .log import logger
-
+from .version import get_device_and_mapping
 
 def check_version():
     """
@@ -40,15 +40,21 @@ def check_version():
         sys.exit(1)
 
 
-def check_gpu():
+def check_device(device):
     """
     Log error and exit when using paddlepaddle cpu version.
     """
-    err = "You are using paddlepaddle cpu version! Please try to " \
-          "install paddlepaddle-gpu to run model on GPU."
+    err = "You are using paddlepaddle %s version! Please try to \n" \
+          "1. install paddlepaddle-%s to run model on %s \nor 2. set the config option 'Global.device' to %s."
 
+    d, supported_device_map = get_device_and_mapping()
+
+    assert device in supported_device_map, \
+        f"the device({device}) to check is not supported by now.Now the paddle only supports: {supported_device_map.keys()}"
+    err = err % (d, device, device, d)
+    
     try:
-        assert is_compiled_with_cuda()
+        assert supported_device_map[device]
     except AssertionError:
         logger.error(err)
         sys.exit(1)

--- a/ppfleetx/utils/config.py
+++ b/ppfleetx/utils/config.py
@@ -305,9 +305,13 @@ def check_config(config):
 
     global_config = config.get('Global')
     check.check_version()
-    use_gpu = global_config.get('device', True)
-    if use_gpu:
-        check.check_gpu()
+    device = global_config.get('device', 'gpu')
+    device = device.lower()
+    if device in ['gpu', 'xpu', 'rocm', 'npu', "cpu"]:
+        check.check_device(device)
+    else:
+        raise ValueError(f"device({device}) is not in ['gpu', 'xpu', 'rocm', 'npu', 'cpu'],\n"
+                "Please ensure the config option Global.device is one of these devices")
 
 
 def override(dl, ks, v):

--- a/ppfleetx/utils/log.py
+++ b/ppfleetx/utils/log.py
@@ -27,6 +27,7 @@ import colorlog
 from colorama import Fore
 
 import paddle
+from .version import get_device
 
 loggers = {}
 
@@ -179,9 +180,14 @@ def advertise():
 
 
 def get_timestamp():
-    paddle.device.cuda.synchronize()
+    if paddle.is_compiled_with_cuda():
+        paddle.device.cuda.synchronize()
+    elif paddle.is_compiled_with_xpu():
+        paddle.device.xpu.synchronize()
+    else:
+        logger.warning(f"the time stamp is only supported on cuda and xpu. "
+        f"However current supported is {get_device()}, which may result uncorrect time")
     return time.time()
-
 
 def convert_timestamp_to_data(timeStamp):
     return str(datetime.timedelta(seconds=int(timeStamp)))

--- a/ppfleetx/utils/version.py
+++ b/ppfleetx/utils/version.py
@@ -19,3 +19,28 @@ def version_check():
     version = paddle.version.full_version
     if version != '0.0.0':
         paddle.utils.require_version(min_version='2.3.0')
+
+
+def get_device_and_mapping():
+    """
+        Return gpu type and name-bool mapping implifying which type is supported.
+    """
+    suppoted_device_map = {
+        "gpu": paddle.is_compiled_with_cuda(),
+        "xpu": paddle.is_compiled_with_xpu(),
+        "rocm": paddle.is_compiled_with_rocm(),
+        "npu": paddle.is_compiled_with_npu(),
+        "cpu": True
+    }
+    for d, v in suppoted_device_map.items():
+        if v:
+            return d, suppoted_device_map
+
+
+def get_device():
+    """
+        Return the GPU Type, including 'gpu'(for rocm and gpu), 'npu', 'xpu', 'cpu'.
+    """
+    d, _ = get_device_and_mapping()
+    return d
+


### PR DESCRIPTION
1. 更新check_gpu, 改为 check_device
2. 避过在XPU上使用 softmax_mask_fuse_upper_triangle(x)， 改为性能较低的 softmax (x + mask)
3. 在XPU/GPU上支持调用 get_timestamp ，在其他硬件上warning提示时间不准确