### PR TITLE
change loss.numpy()[0] to float(loss) to adapt 0D

### DIFF
--- a/examples/transformer/models/GPT/finetune/run.py
+++ b/examples/transformer/models/GPT/finetune/run.py
@@ -175,7 +175,7 @@ if __name__ == "__main__":
             # training step log
             if (step + 1) % config.Global.logging_freq == 0:
                 train_step_cost = log.get_timestamp() - train_step_start
-                numpy_losses = [loss.numpy()[0] for loss in train_losses]
+                numpy_losses = [float(loss) for loss in train_losses]
 
                 train_cost = train_step_cost \
                     if step == 0 else train_step_cost / config.Global.logging_freq
@@ -230,7 +230,7 @@ if __name__ == "__main__":
             loss = impls.eval_impl(config, batch, model, eval_loss_fn,
                                    eval_metric)
 
-            eval_losses.append(loss.numpy()[0])
+            eval_losses.append(float(loss))
 
             if eval_step % config.Global.logging_freq == 0:
                 eval_step_cost = log.get_timestamp() - eval_step_start

--- a/examples/transformer/models/GPT/offline-eval/run.py
+++ b/examples/transformer/models/GPT/offline-eval/run.py
@@ -160,7 +160,7 @@ if __name__ == "__main__":
 
         for eval_step, batch in enumerate(valid_data_loader):
             loss = impls.eval_impl(config, batch, model)
-            eval_losses.append(loss.numpy()[0])
+            eval_losses.append(float(loss))
 
             if eval_step > 0 and eval_step % config.Global.logging_freq == 0:
                 eval_step_cost = log.get_timestamp() - eval_step_start

--- a/examples/transformer/models/GPT/pretrain/run.py
+++ b/examples/transformer/models/GPT/pretrain/run.py
@@ -173,7 +173,7 @@ if __name__ == "__main__":
             # training step log
             if (step + 1) % config.Global.logging_freq == 0:
                 train_step_cost = log.get_timestamp() - train_step_start
-                numpy_losses = [loss.numpy()[0] for loss in train_losses]
+                numpy_losses = [float(loss) for loss in train_losses]
 
                 train_cost = train_step_cost \
                     if step == 0 else train_step_cost / config.Global.logging_freq
@@ -214,7 +214,7 @@ if __name__ == "__main__":
 
                 logger.info(
                     "[eval] epoch: %d, batch: %d, loss: %.9f, avg_eval_cost: %.5f sec, speed: %.2f step/s"
-                    % (epoch_index, eval_step, eval_loss.numpy()[0], eval_cost,
+                    % (epoch_index, eval_step, float(eval_loss), eval_cost,
                        1. / eval_cost))
 
             if step > 0 and config.Global.save_load.save_steps > 0 and \

--- a/ppfleetx/core/engine/eager_engine.py
+++ b/ppfleetx/core/engine/eager_engine.py
@@ -316,7 +316,7 @@ class EagerEngine(BasicEngine):
 
             if (step + 1) % self._logging_freq == 0:
                 train_step_cost = get_timestamp() - train_step_start
-                numpy_losses = [loss.numpy()[0] for loss in train_losses]
+                numpy_losses = [float(loss) for loss in train_losses]
                 log_dict = {
                     'epoch': epoch_index,
                     'total_epoch': self._num_train_epochs,
@@ -354,7 +354,7 @@ class EagerEngine(BasicEngine):
                     eval_loss = sum(eval_losses) / len(eval_losses)
 
                     log_dict = {
-                        'loss': eval_loss.numpy()[0],
+                        'loss': float(eval_loss),
                         'epoch': epoch_index,
                         'batch': eval_step,
                         'total_batch': total_eval_batch,
@@ -555,7 +555,7 @@ class EagerEngine(BasicEngine):
         total_eval_batch = len(valid_data_loader)
         for eval_step, batch in enumerate(valid_data_loader):
             loss = self._evaluate_impl(batch)
-            eval_losses.append(loss.numpy()[0])
+            eval_losses.append(float(loss))
 
             if eval_step % self._logging_freq == 0:
                 eval_step_cost = get_timestamp() - eval_step_start
@@ -612,7 +612,7 @@ class EagerEngine(BasicEngine):
         for test_step, batch in enumerate(test_data_loader):
             loss = self._predict_impl(batch)
 
-            test_losses.append(loss.numpy()[0])
+            test_losses.append(float(loss))
 
             if test_step % self._logging_freq == 0:
                 test_cost = get_timestamp() - test_start


### PR DESCRIPTION
loss正确的语义为0D Tensor，其shape为[]，当前使用了shape为[1]替代，也就是向量Tensor：

在进行升级为0D后，loss.numpy()[0] 的写法不再使用，将其改变为 float(loss) 的写法，在升级前(shape为[1])、升级后(shape为[])下都同样适用，兼容改法。