### PR TITLE
fix 'hidden_size' of gpt_6.7B yaml

### DIFF
--- a/ppfleetx/configs/nlp/gpt/pretrain_gpt_6.7B_single_card.yaml
+++ b/ppfleetx/configs/nlp/gpt/pretrain_gpt_6.7B_single_card.yaml
@@ -8,7 +8,7 @@ Global:
 
 Model:
   vocab_size: 50304
-  hidden_size: 1024
+  hidden_size: 4096
   num_layers: 32
   num_attention_heads: 32
   ffn_hidden_size: 16384


### PR DESCRIPTION
fix 'hidden_size' of gpt_6.7B in pretraining