### PR TITLE
fix_recompute_bug

### DIFF
--- a/ppfleetx/core/engine/eager_engine.py
+++ b/ppfleetx/core/engine/eager_engine.py
@@ -442,8 +442,13 @@ class EagerEngine(BasicEngine):
                     loss = self._model_forward_backward(batch)
                 if not hasattr(self._optimizer, "all_fused_tensors"
                                ) or self._optimizer.all_fused_tensors is None:
-                    fused_allreduce_gradients(
-                        list(self._module.model.parameters()), None)
+                    try:
+                        fused_allreduce_gradients(
+                            list(self._module.model.parameters()), None)
+                    except:
+                        m = self._module.model.state_dict()
+                        fused_allreduce_gradients(
+                            list(self._module.model.parameters()), None)
                 else:
                     all_reduce_parameters(self._optimizer.all_fused_tensors,
                                           self._dp_group)


### PR DESCRIPTION
目的：解决Imagen 256 超分模型在recompute下报错问题
临时方案：在 fused_allreduce_gradients 之前添加 m = self._module.model.state_dict() 可以临时解决该问题
           