### PR TITLE
Add the support of bfloat16 amp training.

### DIFF
--- a/ppfleetx/configs/nlp/gpt/pretrain_gpt_base.yaml
+++ b/ppfleetx/configs/nlp/gpt/pretrain_gpt_base.yaml
@@ -17,6 +17,8 @@ Engine:
   test_iters:
   mix_precision:
     use_pure_fp16: True
+    dtype: "float16"
+    level: "O2"
     scale_loss: 32768.0
     custom_black_list: ["reduce_sum", "c_softmax_with_cross_entropy", "elementwise_div"]
     custom_white_list: ["lookup_table", "lookup_table_v2"]
@@ -90,6 +92,7 @@ Profiler:
   scheduler: [1, 5]
   profiler_log: profiler_log
   detailed: False
+
 
 Distributed:
   fuse_sequence_parallel_allreduce: False

--- a/ppfleetx/configs/nlp/gpt/pretrain_gpt_base.yaml
+++ b/ppfleetx/configs/nlp/gpt/pretrain_gpt_base.yaml
@@ -84,6 +84,7 @@ Optimizer:
   grad_clip:
     name: "ClipGradByGlobalNorm"
     clip_norm: 1.0
+    multi_precision: False
   tensor_fusion: False
 
 

--- a/ppfleetx/core/engine/eager_engine.py
+++ b/ppfleetx/core/engine/eager_engine.py
@@ -138,9 +138,9 @@ class EagerEngine(BasicEngine):
 
         self._amp_dtype = amp_config.get('dtype', 'float16')
         self._amp_level = amp_config.get('level', 'O2')
-        self._scale_loss = amp_config('scale_loss')
-        self._custom_black_list = amp_config('custom_black_list')
-        self._custom_white_list = amp_config('custom_white_list')
+        self._scale_loss = amp_config['scale_loss']
+        self._custom_black_list = amp_config['custom_black_list']
+        self._custom_white_list = amp_config['custom_white_list']
 
         self._save_steps = self._configs['save_load']['save_steps']
         self._save_epoch = self._configs['save_load']['save_epoch']
@@ -334,6 +334,8 @@ class EagerEngine(BasicEngine):
                     'loss': sum(numpy_losses) / len(numpy_losses),
                     'lr': self._optimizer.get_lr()
                 }
+                if self._use_pure_fp16:
+                    log_dict['loss_scale'] = self._scaler._scale
                 self._module.training_step_end(log_dict)
 
                 train_step_start = get_timestamp()

--- a/ppfleetx/core/engine/eager_engine.py
+++ b/ppfleetx/core/engine/eager_engine.py
@@ -130,18 +130,17 @@ class EagerEngine(BasicEngine):
         self._num_train_epochs = self._configs['num_train_epochs']
         self._accumulate_steps = self._configs['accumulate_steps']
 
-        self._use_pure_fp16 = self._configs['mix_precision']['use_pure_fp16']
+        amp_config = self._configs['mix_precision']
+        self._use_pure_fp16 = amp_config['use_pure_fp16']
         if mode == 'export' and self._use_pure_fp16:
             logger.info("NOTE: disable use_pure_fp16 in export mode")
             self._use_pure_fp16 = False
 
-        self._amp_dtype = self._configs['mix_precision']['dtype']
-        self._amp_level = self._configs['mix_precision']['level']
-        self._scale_loss = self._configs['mix_precision']['scale_loss']
-        self._custom_black_list = self._configs['mix_precision'][
-            'custom_black_list']
-        self._custom_white_list = self._configs['mix_precision'][
-            'custom_white_list']
+        self._amp_dtype = amp_config.get('dtype', 'float16')
+        self._amp_level = amp_config.get('level', 'O2')
+        self._scale_loss = amp_config('scale_loss')
+        self._custom_black_list = amp_config('custom_black_list')
+        self._custom_white_list = amp_config('custom_white_list')
 
         self._save_steps = self._configs['save_load']['save_steps']
         self._save_epoch = self._configs['save_load']['save_epoch']

--- a/ppfleetx/models/language_model/language_module.py
+++ b/ppfleetx/models/language_model/language_module.py
@@ -75,11 +75,18 @@ class LanguageModule(BasicModule):
         default_global_tokens_num = self.configs.Global.global_batch_size * \
             self.configs.Data.Train.dataset.max_seq_len
 
-        logger.info(
-            "[train] epoch: %d, batch: %d, loss: %.9f, avg_batch_cost: %.5f sec, speed: %.2f step/s, " \
-            "ips_total: %.0f tokens/s, ips: %.0f tokens/s, learning rate: %.5e"
-            % (log_dict['epoch'], log_dict['batch'], log_dict['loss'], log_dict['train_cost'], speed,
-               speed * default_global_tokens_num, speed * default_global_tokens_num / self.data_world_size, log_dict['lr']))
+        if log_dict.get('loss_scale', None) is not None:
+            logger.info(
+                "[train] epoch: %d, batch: %d, loss: %.9f, loss_scale: %.2f, avg_batch_cost: %.5f sec, speed: %.2f step/s, " \
+                "ips_total: %.0f tokens/s, ips: %.0f tokens/s, learning rate: %.5e"
+                % (log_dict['epoch'], log_dict['batch'], log_dict['loss'], log_dict['loss_scale'], log_dict['train_cost'], speed,
+                   speed * default_global_tokens_num, speed * default_global_tokens_num / self.data_world_size, log_dict['lr']))
+        else:
+            logger.info(
+                "[train] epoch: %d, batch: %d, loss: %.9f, avg_batch_cost: %.5f sec, speed: %.2f step/s, " \
+                "ips_total: %.0f tokens/s, ips: %.0f tokens/s, learning rate: %.5e"
+                % (log_dict['epoch'], log_dict['batch'], log_dict['loss'], log_dict['train_cost'], speed,
+                   speed * default_global_tokens_num, speed * default_global_tokens_num / self.data_world_size, log_dict['lr']))
 
     def validation_step(self, batch):
         tokens, position_ids, labels, loss_mask = batch

--- a/ppfleetx/optims/__init__.py
+++ b/ppfleetx/optims/__init__.py
@@ -43,6 +43,9 @@ def build_lr_scheduler(lr_config):
 
 def build_grad_clip(grad_clip_config):
     if grad_clip_config is not None:
+        multi_precision = grad_clip_config.pop('multi_precision', False)
+        if multi_precision:
+            paddle.nn.clip._clip_by_global_norm_using_mp_type(True)
         grad_clip_name = grad_clip_config.pop('name', 'ClipGradByGlobalNorm')
         grad_clip = eval(grad_clip_name)(**grad_clip_config)
         return grad_clip


### PR DESCRIPTION
增加AMP-BF16训练，训练345M GPT-3模型的命令如下：
```bash
python tools/train.py \
    -c ppfleetx/configs/nlp/gpt/pretrain_gpt_345M_single_card.yaml \
    -o Engine.mix_precision.use_pure_fp16="True" \
    -o Engine.mix_precision.dtype="bfloat16" \
    -o Engine.mix_precision.level="O2" \
    -o Optimizer.grad_clip.multi_precision=True
```