### PR TITLE
Integrate flash-attention into PaddleFleetX

### DIFF
--- a/ppfleetx/configs/nlp/gpt/finetune_gpt_base.yaml
+++ b/ppfleetx/configs/nlp/gpt/finetune_gpt_base.yaml
@@ -24,3 +24,6 @@ Profiler:
   scheduler: [1, 5]
   profiler_log: profiler_log
   detailed: False
+
+Model:
+  use_flash_attn: False

--- a/ppfleetx/configs/nlp/gpt/pretrain_gpt_base.yaml
+++ b/ppfleetx/configs/nlp/gpt/pretrain_gpt_base.yaml
@@ -33,6 +33,7 @@ Model:
   fused_linear: False
   fuse_attn_qkv: True
   sequence_parallel: False
+  use_flash_attn: False
 
 
 Data:

--- a/ppfleetx/core/engine/eager_engine.py
+++ b/ppfleetx/core/engine/eager_engine.py
@@ -1,11 +1,11 @@
 # Copyright (c) 2022 PaddlePaddle Authors. All Rights Reserved.
-# 
+#
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
-# 
+#
 #     http://www.apache.org/licenses/LICENSE-2.0
-# 
+#
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -45,7 +45,7 @@ from ppfleetx.utils.compression_helper import prune_model, quant_model
 
 class EagerEngine(BasicEngine):
     """
-    The common engine for all models that support single-card and distributed 
+    The common engine for all models that support single-card and distributed
     training, validation and test. Only used in eager dygraph mode.
     """
 
@@ -55,13 +55,13 @@ class EagerEngine(BasicEngine):
 
         Args:
 
-            module(BasicModule): user-defined module. After assigning computations 
-                and configurations of model/optimizers/lr Schedulers, engine can 
+            module(BasicModule): user-defined module. After assigning computations
+                and configurations of model/optimizers/lr Schedulers, engine can
                 support the whole loop of training/validation/test.
-            
-            configs(dict): the configurations that engine needs for training/validation/test 
+
+            configs(dict): the configurations that engine needs for training/validation/test
                 loop. Such as mix precision strategy, save&load and the infos of steps/epoches.
-        
+
         Return:
 
             An instance of `EagerEngine`.
@@ -175,13 +175,14 @@ class EagerEngine(BasicEngine):
         self._broadcast_overlap = sharding_config['broadcast_overlap']
 
         self._use_recompute = configs['Model']['use_recompute']
+        self._use_flash_attn = configs['Model']['use_flash_attn']
 
         if self._use_pure_fp16:
             if mode == 'train':
                 self._scaler = paddle.amp.GradScaler(
                     init_loss_scaling=self._scale_loss)
 
-            # Save dtype is the same as model dtype. Also can set save_dtype='float32' when 
+            # Save dtype is the same as model dtype. Also can set save_dtype='float32' when
             # training with pure fp16 strategy, but will cause the rise of memory.
             self._module.model = paddle.amp.decorate(
                 models=self._module.model, level='O2')
@@ -381,7 +382,7 @@ class EagerEngine(BasicEngine):
         Args:
 
             epoch(int): the epoch index.
-            
+
             train_data_loader(DataLoader, None): a collection of :class:`paddle.io.DataLoader`, specifying training samples.
 
             valid_data_loader(DataLoader, None): a collection of :class:`paddle.io.DataLoader`, specifying validation samples.
@@ -606,7 +607,7 @@ class EagerEngine(BasicEngine):
         Args:
 
             epoch(int): the epoch index.
-            
+
             test_data_loader(DataLoader, None): a collection of :class:`paddle.io.DataLoader`, specifying test samples.
 
         """

--- a/ppfleetx/core/engine/eager_engine.py
+++ b/ppfleetx/core/engine/eager_engine.py
@@ -175,7 +175,6 @@ class EagerEngine(BasicEngine):
         self._broadcast_overlap = sharding_config['broadcast_overlap']
 
         self._use_recompute = configs['Model']['use_recompute']
-        self._use_flash_attn = configs['Model']['use_flash_attn']
 
         if self._use_pure_fp16:
             if mode == 'train':

--- a/ppfleetx/models/language_model/gpt/dygraph/hybrid_model.py
+++ b/ppfleetx/models/language_model/gpt/dygraph/hybrid_model.py
@@ -202,8 +202,8 @@ class MultiHeadAttention(nn.Layer):
 
         if isinstance(cache, self.Cache):
             # for decoder self-attention in inference
-            k = tensor.concat([cache.k, k], axis=2)
-            v = tensor.concat([cache.v, v], axis=2)
+            k = tensor.concat([cache.k, k], axis=1)
+            v = tensor.concat([cache.v, v], axis=1)
         if use_cache is True:
             cache = self.Cache(k, v)
 
@@ -227,8 +227,8 @@ class MultiHeadAttention(nn.Layer):
 
         if isinstance(cache, self.Cache):
             # for decoder self-attention in inference
-            k = tensor.concat([cache.k, k], axis=2)
-            v = tensor.concat([cache.v, v], axis=2)
+            k = tensor.concat([cache.k, k], axis=1)
+            v = tensor.concat([cache.v, v], axis=1)
         if use_cache is True:
             cache = self.Cache(k, v)
 

--- a/ppfleetx/models/language_model/gpt/dygraph/hybrid_model.py
+++ b/ppfleetx/models/language_model/gpt/dygraph/hybrid_model.py
@@ -278,7 +278,13 @@ class MultiHeadAttention(nn.Layer):
             return self.Cache(key, value)
 
     def _flash_attention(self, q, k, v, attn_mask=None):
-        out, weights = flash_attention(q, k, v, self.dropout, True, True)
+        out, weights = flash_attention(
+            q,
+            k,
+            v,
+            self.dropout,
+            causal=True,
+            return_softmax=self.need_weights)
         out = tensor.reshape(x=out, shape=[0, 0, out.shape[2] * out.shape[3]])
         return out, weights
 

--- a/ppfleetx/models/language_model/gpt/dygraph/single_model.py
+++ b/ppfleetx/models/language_model/gpt/dygraph/single_model.py
@@ -150,8 +150,8 @@ class MultiHeadAttention(nn.Layer):
 
         if isinstance(cache, self.Cache):
             # for decoder self-attention in inference
-            k = tensor.concat([cache.k, k], axis=2)
-            v = tensor.concat([cache.v, v], axis=2)
+            k = tensor.concat([cache.k, k], axis=1)
+            v = tensor.concat([cache.v, v], axis=1)
         if use_cache is True:
             cache = self.Cache(k, v)
 
@@ -175,8 +175,8 @@ class MultiHeadAttention(nn.Layer):
 
         if isinstance(cache, self.Cache):
             # for decoder self-attention in inference
-            k = tensor.concat([cache.k, k], axis=2)
-            v = tensor.concat([cache.v, v], axis=2)
+            k = tensor.concat([cache.k, k], axis=1)
+            v = tensor.concat([cache.v, v], axis=1)
         if use_cache is True:
             cache = self.Cache(k, v)
 

--- a/ppfleetx/models/language_model/gpt/dygraph/single_model.py
+++ b/ppfleetx/models/language_model/gpt/dygraph/single_model.py
@@ -634,6 +634,7 @@ class GPTModel(nn.Layer):
             if flash_attention:
                 logger.info("Flash-attention enabled.")
             else:
+                use_flash_attn = False
                 logger.warning(
                     "Flash-attention is not support in this Paddle version.")
 

--- a/ppfleetx/models/language_model/gpt/dygraph/single_model.py
+++ b/ppfleetx/models/language_model/gpt/dygraph/single_model.py
@@ -35,6 +35,12 @@ from .processor import (
 from ppfleetx.models.language_model.moe import MoELayer
 from ppfleetx.models.language_model.moe_exp.layer import MoE
 
+from ppfleetx.utils.log import logger
+try:
+    from paddle.nn.functional.flash_attention import flash_attention
+except:
+    flash_attention = None
+
 
 def get_attr(layer, name):
     if getattr(layer, name, None) is not None:
@@ -94,7 +100,8 @@ class MultiHeadAttention(nn.Layer):
                  fused_linear=False,
                  use_recompute=False,
                  recompute_granularity="full",
-                 do_recompute=True):
+                 do_recompute=True,
+                 use_flash_attn=False):
         super(MultiHeadAttention, self).__init__()
         self.embed_dim = embed_dim
         self.kdim = kdim if kdim is not None else embed_dim
@@ -106,6 +113,7 @@ class MultiHeadAttention(nn.Layer):
         self.use_recompute = use_recompute
         self.recompute_granularity = recompute_granularity
         self.do_recompute = do_recompute
+        self.use_flash_attn = use_flash_attn if flash_attention else None
 
         self.head_dim = embed_dim // num_heads
         assert self.head_dim * \
@@ -146,7 +154,7 @@ class MultiHeadAttention(nn.Layer):
         if use_cache is True:
             cache = self.Cache(k, v)
 
-        return (q, k, v) if use_cache is False else (q, k, v, cache)
+        return (q, k, v, cache) if use_cache else (q, k, v, None)
 
     def _prepare_qkv(self, query, key, value, use_cache=False, cache=None):
         r"""
@@ -172,7 +180,7 @@ class MultiHeadAttention(nn.Layer):
         if use_cache is True:
             cache = self.Cache(k, v)
 
-        return (q, k, v) if use_cache is False else (q, k, v, cache)
+        return (q, k, v, cache) if use_cache else (q, k, v, None)
 
     def compute_kv(self, key, value):
         r"""
@@ -219,6 +227,14 @@ class MultiHeadAttention(nn.Layer):
             # incremental_state with initial value, mainly for usage like UniLM
             return self.Cache(key, value)
 
+    def _flash_attention(self, q, k, v):
+        q = tensor.transpose(x=q, perm=[0, 2, 1, 3])
+        k = tensor.transpose(x=k, perm=[0, 2, 1, 3])
+        v = tensor.transpose(x=v, perm=[0, 2, 1, 3])
+        out, weights = flash_attention(q, k, v, self.dropout, True, True)
+        out = tensor.reshape(x=out, shape=[0, 0, out.shape[2] * out.shape[3]])
+        return out, weights
+
     def core_attn(self, q, k, v, attn_mask=None):
         # scale dot product attention
         product = paddle.matmul(
@@ -259,22 +275,16 @@ class MultiHeadAttention(nn.Layer):
         key = query if key is None else key
         value = query if value is None else value
         # compute q ,k ,v
-        if use_cache is False:
-            if self.fuse_attn_qkv:
-                q, k, v = self._fuse_prepare_qkv(query, use_cache, cache)
-            else:
-                q, k, v = self._prepare_qkv(query, key, value, use_cache,
-                                            cache)
+        if self.fuse_attn_qkv:
+            q, k, v, cache = self._fuse_prepare_qkv(query, use_cache, cache)
         else:
-            if self.fuse_attn_qkv:
-                q, k, v, cache = self._fuse_prepare_qkv(query, use_cache,
-                                                        cache)
-            else:
-                q, k, v, cache = self._prepare_qkv(query, key, value,
-                                                   use_cache, cache)
+            q, k, v, cache = self._prepare_qkv(query, key, value, use_cache,
+                                               cache)
 
         if self.use_recompute and self.recompute_granularity == "core_attn" and self.do_recompute:
             out, weights = recompute(self.core_attn, q, k, v, attn_mask)
+        elif self.use_flash_attn and attn_mask is None:
+            out, weights = self._flash_attention(q, k, v)
         else:
             out, weights = self.core_attn(q, k, v, attn_mask=attn_mask)
 
@@ -406,7 +416,8 @@ class TransformerDecoderLayer(nn.Layer):
                  use_recompute=False,
                  recompute_granularity="full",
                  do_recompute=True,
-                 skip_quant_tensors=[]):
+                 skip_quant_tensors=[],
+                 use_flash_attn=False):
         self._config = locals()
         self._config.pop("self")
         self._config.pop("__class__", None)  # py3
@@ -436,11 +447,12 @@ class TransformerDecoderLayer(nn.Layer):
             fuse_attn_qkv=fuse_attn_qkv,
             use_recompute=use_recompute,
             recompute_granularity=recompute_granularity,
-            do_recompute=do_recompute)
-            
+            do_recompute=do_recompute,
+            use_flash_attn=use_flash_attn)
+
         self.moe_mlp = None
         if self.num_experts > 1:
-            assert(topk==1, "Only support topk=1 currently.")
+            assert (topk == 1, "Only support topk=1 currently.")
             self.moe_mlp = MoE(
                 d_model,
                 ExpertLayer(d_model, dim_feedforward),
@@ -598,7 +610,8 @@ class GPTModel(nn.Layer):
                  sequence_parallel=False,
                  no_recompute_layers=None,
                  skip_tensor_map={},
-                 freeze_embedding=False):
+                 freeze_embedding=False,
+                 use_flash_attn=False):
 
         super(GPTModel, self).__init__()
 
@@ -607,6 +620,13 @@ class GPTModel(nn.Layer):
         self.initializer_range = initializer_range
         self.hidden_size = hidden_size
         self.vocab_size = vocab_size
+
+        if use_flash_attn:
+            if flash_attention:
+                logger.info("Flash-attention enabled.")
+            else:
+                logger.warning(
+                    "Flash-attention is not support in this Paddle version.")
 
         self.embeddings = GPTEmbeddings(
             vocab_size, hidden_size, hidden_dropout_prob,
@@ -655,7 +675,8 @@ class GPTModel(nn.Layer):
                     recompute_granularity=recompute_granularity,
                     do_recompute=i not in no_recompute_layers,
                     skip_quant_tensors=skip_tensor_map.get('block_{}'.format(
-                        i), [])))
+                        i), []),
+                    use_flash_attn=use_flash_attn))
 
         self.decoder = TransformerDecoder(
             decoder_layers,


### PR DESCRIPTION
Integrate flash-attention into PaddleFleetX.

Usage
single card
```shell
python ./tools/train.py -c ./ppfleetx/configs/nlp/gpt/pretrain_gpt_345M_single_card.yaml -o Model.use_flash_attn=True
```
dp8
```
python -m paddle.distributed.launch python ./tools/train.py -c ./ppfleetx/configs/nlp/gpt/pretrain_gpt_1.3B_dp8.yaml -o Model.use_flash_attn=True
```

Performance impact example:

-o Model.use_flash_attn=False
```
[2023-02-27 06:57:22,100] [INFO] - [train] epoch: 0, batch: 7, loss: 11.238356590, avg_batch_cost: 0.81305 sec, speed: 1.23 step/s, ips_total: 80605 tokens/s, ips: 10076 tokens/s, learning rate: 1.11111e-07
```
-o Model.use_flash_attn=True
```
[2023-02-27 06:55:53,127] [INFO] - [train] epoch: 0, batch: 7, loss: 11.240215302, avg_batch_cost: 0.73253 sec, speed: 1.37 step/s, ips_total: 89465 tokens/s, ips: 11183 tokens/s, learning rate: 1.11111e-07
```



