### PR TITLE
disable kernel promotion for amp traning

### DIFF
--- a/ppfleetx/core/engine/eager_engine.py
+++ b/ppfleetx/core/engine/eager_engine.py
@@ -142,6 +142,7 @@ class EagerEngine(BasicEngine):
 
         self._amp_dtype = amp_config.get('dtype', 'float16')
         self._amp_level = amp_config.get('level', 'O2')
+        self._amp_use_promote = amp_config.get('use_promote', False)
         self._use_main_grad = amp_config.get('use_main_grad', False)
         self._scale_loss = amp_config['scale_loss']
         self._custom_black_list = amp_config['custom_black_list']
@@ -510,7 +511,8 @@ class EagerEngine(BasicEngine):
                     custom_black_list=self._custom_black_list,
                     custom_white_list=self._custom_white_list,
                     dtype=self._amp_dtype,
-                    level=self._amp_level):
+                    level=self._amp_level,
+                    use_promote=self._amp_use_promote):
                 batch = self._module.model._prepare_training(
                     batch, self._optimizer, self._lr_scheduler)
                 loss = self._module.model.forward_backward_pipeline(
@@ -537,7 +539,8 @@ class EagerEngine(BasicEngine):
                     custom_black_list=self._custom_black_list,
                     custom_white_list=self._custom_white_list,
                     dtype=self._amp_dtype,
-                    level=self._amp_level):
+                    level=self._amp_level,
+                    use_promote=self._amp_use_promote):
                 loss = self._module.training_step(micro_batch)
 
             if self._amp_enable and self._amp_dtype == "float16":
@@ -648,7 +651,8 @@ class EagerEngine(BasicEngine):
                 custom_black_list=self._custom_black_list,
                 custom_white_list=self._custom_white_list,
                 dtype=self._amp_dtype,
-                level=self._amp_level):
+                level=self._amp_level,
+                use_promote=self._amp_use_promote):
             if self._pp_degree == 1:
                 loss = self._module.validation_step(batch)
             else:
@@ -706,7 +710,8 @@ class EagerEngine(BasicEngine):
                 custom_black_list=self._custom_black_list,
                 custom_white_list=self._custom_white_list,
                 dtype=self._amp_dtype,
-                level=self._amp_level):
+                level=self._amp_level,
+                use_promote=self._amp_use_promote):
             if self._pp_degree == 1:
                 loss = self._module.test_step(batch)
             else:


### PR DESCRIPTION
背景：过去框架AMP在O2模式下，当OP支持低精度就会选择低精度的kernel，但这样的策略出现精度问题的风险较高。为保障训练精度，框架在2.5版本对AMP 策略进行了调整，即在O2模式下，仅当Op所有输入为低精度时才会选择低精度kernel，否则则采用FP32 Kernel（即promote的策略），因此可能会引起部分模型出现性能下降。

目前可以通过给auto_cast设置use_promote=False参数来回退到旧版本的O2策略，本PR给套件添加该参数的设置功能，当前套件默认设置为use_promote=False，使用的是旧版本的O2策略，以解决性能下降问题。

PaddlePaddle框架动态图下默认的行为是use_promote=True，未来可以根据模型特点进行调试。

框架PR：https://github.com/PaddlePaddle/Paddle/pull/53742